### PR TITLE
Support additional S3 fields

### DIFF
--- a/lib/shrine/plugins/direct_upload.rb
+++ b/lib/shrine/plugins/direct_upload.rb
@@ -179,6 +179,7 @@ class Shrine
               r.get "presign" do
                 location = SecureRandom.hex(30).to_s + r.params["extension"].to_s
                 options = {}
+                options.merge!(r.params["fields"].symbolize_keys) if r.params["fields"]
                 options[:content_length_range] = 0..max_size if max_size
                 options[:content_type] = r.params["content_type"] if r.params["content_type"]
 


### PR DESCRIPTION
This allows us to pass in additional fields from the official doc, while maintaining server-side set size range.

Very useful if you want to set a redirect for example, you can add to your params:

```
fields: {
  success_action_redirect: 'http://example.org/<my_success_callback>'
}
```

http://docs.aws.amazon.com/AmazonS3/latest/dev/HTTPPOSTForms.html

