### PR TITLE
Ruby 2.3 bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,15 @@ sudo: false
 rvm:
   - "2.1"
   - "2.2"
+  - "ruby-head"
   - "jruby-9.0.4.0"
+  - "jruby-head"
   - "rbx-2.5.8"
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: jruby-head
 
 script: bundle exec rake test
 

--- a/test/file_system_test.rb
+++ b/test/file_system_test.rb
@@ -61,6 +61,12 @@ describe Shrine::Storage::FileSystem do
       assert_equal "image", input.read
     end
 
+    it "copies full file content" do
+      @storage.upload(input = fakeio("A" * 20_000), "foo.jpg")
+
+      assert_equal 20_000, @storage.open("foo.jpg").size
+   end
+
     it "sets file permissions" do
       @storage = file_system(root, permissions: 0755)
       @storage.upload(fakeio, "foo.jpg")


### PR DESCRIPTION
I run into this issue when running my app using `2.3.0-preview1`. Only the last block of the file would be copied. Not sure why it happens but it seems that `IO.copy_stream(io, filename)`  no longer works as expected. So I changed it to `IO.copy_stream(io, io)`