### PR TITLE
Pretty location generates shorter file IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Reduce length of URLs generated with pretty_location plugin (gshaw)
+
 * Improve Windows compatibility in the FileSystem storage (janko-m)
 
 * Remove the ability for FileSystem storage to accept IDs starting with a slash (janko-m)

--- a/lib/shrine/plugins/pretty_location.rb
+++ b/lib/shrine/plugins/pretty_location.rb
@@ -13,6 +13,11 @@ class Shrine
     #     # :model/:id/:attachment/:version-:uid.:extension
     module PrettyLocation
       module InstanceMethods
+        def generate_uid(_io)
+          length = 10
+          SecureRandom.random_number(36**length).to_s(36).ljust(length, "0")
+        end
+
         def generate_location(io, context)
           type = context[:record].class.name.downcase if context[:record] && context[:record].class.name
           id   = context[:record].id if context[:record].respond_to?(:id)

--- a/test/plugin/pretty_location_test.rb
+++ b/test/plugin/pretty_location_test.rb
@@ -9,11 +9,16 @@ describe "the pretty_location plugin" do
   it "uses context to build the directory" do
     uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(id: 123), name: :avatar)
 
-    assert_match %r{^openstruct/123/avatar/[\w-]+$}, uploaded_file.id
+    assert_match %r{\Aopenstruct/123/avatar/[\w-]+\z}, uploaded_file.id
   end
 
   it "prepends version names to generated location" do
     uploaded_file = @uploader.upload(fakeio(filename: "foo.jpg"), version: :thumb)
-    assert_match %r{^thumb-[\w-]+.jpg$}, uploaded_file.id
+    assert_match %r{\Athumb-[\w-]+\.jpg\z}, uploaded_file.id
+  end
+
+  it "appends a 10 character alphanumeric string suffix" do
+    uploaded_file = @uploader.upload(fakeio(filename: "bar.png"), version: :square)
+    assert_match %r{\Asquare-[a-z0-9]{10}+\.png\z}, uploaded_file.id
   end
 end


### PR DESCRIPTION
Generate a 10 character alpha numeric string for cleaner file URLs.

Did not update the docs because the example in the plugin already shows it generating a 10 character suffix.
