### PR TITLE
Provide S3 options for CloudFront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Add `cache_control` and `acl` parameters to S3 storage for CloudFront (gshaw)
+
 * Improve Windows compatibility in the FileSystem storage (janko-m)
 
 * Remove the ability for FileSystem storage to accept IDs starting with a slash (janko-m)

--- a/README.md
+++ b/README.md
@@ -527,6 +527,8 @@ s3_options = {
   secret_access_key: "<SECRET_ACCESS_KEY>",  # "abc"
   region:            "<REGION>",             # "eu-west-1"
   bucket:            "<BUCKET>",             # "my-app"
+  cache_control:     "public, max-age=#{30.days}",
+  acl:               "public-read"
 }
 
 Shrine.storages = {


### PR DESCRIPTION
Specify Cache Control and ACL options for S3 uploads so that CloudFront can server the files as expected.

I'm not sure if this is the best way to accomplish this but I was only able to server uploaded assets over CloudFront by setting those two options.

More than happy to refactor this if given some guidance.  Especially as to how to test this.
