### PR TITLE
Change Lotus into Hanami

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,8 +563,8 @@
           <ul>
             
             <li>
-              <a href="https://github.com/katafrakt/lotus-shrine">
-                lotus-shrine
+              <a href="https://github.com/katafrakt/hanami-shrine">
+                hanami-shrine
               </a>
             </li>
             
@@ -624,8 +624,8 @@
             </li>
             
             <li>
-              <a href="https://github.com/katafrakt/lotus-shrine-example">
-                Lotus example app
+              <a href="https://github.com/katafrakt/hanami-shrine-example">
+                Hanami example app
               </a>
             </li>
             


### PR DESCRIPTION
Lotus [has changed its name to Hanami](http://hanamirb.org/blog/2016/01/22/lotus-is-now-hanami.html) and so did my gem and example repository. This PR fixes URLs and names.