### PR TITLE
Promote hooks

### DIFF
--- a/lib/shrine/plugins/hooks.rb
+++ b/lib/shrine/plugins/hooks.rb
@@ -151,6 +151,27 @@ class Shrine
 
         def after_delete(*)
         end
+
+
+        def around_promote(*args)
+          before_promote(*args)
+          result = yield
+          after_promote(*args)
+        end
+
+        def before_promote(*)
+        end
+
+        def after_promote(*)
+        end
+      end
+
+      module AttacherMethods
+        def promote(cached_file)
+          result = nil
+          store.around_promote(cached_file, record: record) { result = super }
+          result
+        end
       end
     end
 

--- a/lib/shrine/plugins/hooks.rb
+++ b/lib/shrine/plugins/hooks.rb
@@ -107,9 +107,7 @@ class Shrine
     #         }
     #         super
     #       end
-    #     end
     #
-    #     class ImageUploader < Shrine
     #       def after_promote(cached_file, record:)
     #         cached_file #=> {
     #           "id": "43kewit94.jpg",

--- a/test/plugin/hooks_test.rb
+++ b/test/plugin/hooks_test.rb
@@ -2,7 +2,8 @@ require "test_helper"
 
 describe "the hooks plugin" do
   before do
-    @uploader = uploader { plugin :hooks }
+    @attacher = attacher { plugin :hooks }
+    @uploader = @attacher.store
   end
 
   it "provides uploading hooks" do
@@ -109,6 +110,38 @@ describe "the hooks plugin" do
         "before_delete",
         "after_delete",
         "after around_delete",
+      ],
+      @uploader.instance_variable_get("@hooks")
+  end
+
+  it "provides promote hooks" do
+    @uploader.instance_eval do
+      def around_promote(cached_file, *args)
+        @hooks = []
+        @hooks << "before around_promote"
+        super
+        @hooks << "after around_promote"
+      end
+
+      def before_promote(cached_file, *args)
+        @hooks << "before_promote"
+        super
+      end
+
+      def after_promote(cached_file, *args)
+        super
+        @hooks << "after_promote"
+      end
+    end
+
+    @attacher.promote(fakeio)
+
+    assert_equal \
+      [
+        "before around_promote",
+        "before_promote",
+        "after_promote",
+        "after around_promote",
       ],
       @uploader.instance_variable_get("@hooks")
   end


### PR DESCRIPTION
Hi @janko-m,

After thinking about your response to #36, I came up with a (hopefully) acceptable solution. This PR adds hooks to the `promote` method.

After this PR, you may write an uploader like follows:

```ruby
class AttachmentUploader < Shrine
  plugin :backgrounding
  plugin :hooks
  plugin :versions, names: [:original, :thumb]

  def process(io, context)
    if context[:phase] == :store
      thumb = resize_to_limit!(io.download, 350, 350)
      {original: io, thumb: thumb}
    end
  end

  def after_promote(cached_file, record:)
    cached_file.delete
  end
end

```

The `after_promote` hook will run after the `store` versions have been uploaded and the new value is persisted to the DB. Deleting the cache file here leaves 0 time when the store and DB are in an inconsistent state. I hope you find this an acceptable solution to all the issues discussed in #36. Let me know if I can improve this PR in anyway. Thanks for your time!