### PR TITLE
Avoid opening an UploadedFile just in order to close it

### DIFF
--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -717,8 +717,10 @@ class Shrine
         # Part of Shrine::UploadedFile's complying to the IO interface.  It
         # delegates to the internally downloaded file.
         def close
-          io.close
-          io.delete if io.class.name == "Tempfile"
+          if @io
+            io.close
+            io.delete if io.class.name == "Tempfile"
+          end
         end
 
         # Part of Shrine::UploadedFile's complying to the IO interface.  It

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -71,6 +71,17 @@ describe Shrine::UploadedFile do
     assert tempfile.path.nil?
   end
 
+  it "doesn't open an IO just in order to close it" do
+    uploaded_file = @uploader.class.uploaded_file(
+      'id' => '123',
+      'storage' => 'cache',
+      'metadata' => { 'size' => 1 }
+    )
+
+    uploaded_file.storage.expects(:open).never
+    uploaded_file.close
+  end
+
   it "has storage related methods" do
     uploaded_file = @uploader.upload(fakeio("image"), location: "key")
 


### PR DESCRIPTION
I'm using Shrine to manage direct S3 uploads and was seeing an unexpected GET to S3 during the `after_commit` phase. This came to light when writing some tests using [webmock](https://github.com/bblimke/webmock) to stub all external network requests.

In the case of an S3 `UploadedFile` that's been initialized from JSON with no processing step required, the copy happily happens on the server and `UploadedFile#io` never needs to be populated. But after the copy completes, the `ensure` block of `UploadedFile#copy` calls `UploadedFile#close`, which references the unpopulated `UploadedFile#io` and triggers `UploadedFile#open`.