### PR TITLE
Pretty location plugin with namespaced models

### DIFF
--- a/lib/shrine/plugins/pretty_location.rb
+++ b/lib/shrine/plugins/pretty_location.rb
@@ -14,7 +14,7 @@ class Shrine
     module PrettyLocation
       module InstanceMethods
         def generate_location(io, context)
-          type = context[:record].class.name.downcase if context[:record] && context[:record].class.name
+          type = context[:record].class.name.downcase.gsub('::', '/') if context[:record] && context[:record].class.name
           id   = context[:record].id if context[:record].respond_to?(:id)
           name = context[:name]
 

--- a/test/plugin/pretty_location_test.rb
+++ b/test/plugin/pretty_location_test.rb
@@ -2,14 +2,18 @@ require "test_helper"
 require "ostruct"
 
 describe "the pretty_location plugin" do
+  module NameSpaced
+    class OpenStruct < ::OpenStruct; end
+  end
+
   before do
     @uploader = uploader { plugin :pretty_location }
   end
 
   it "uses context to build the directory" do
-    uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(id: 123), name: :avatar)
+    uploaded_file = @uploader.upload(fakeio, record: NameSpaced::OpenStruct.new(id: 123), name: :avatar)
 
-    assert_match %r{^openstruct/123/avatar/[\w-]+$}, uploaded_file.id
+    assert_match %r{^namespaced/openstruct/123/avatar/[\w-]+$}, uploaded_file.id
   end
 
   it "prepends version names to generated location" do


### PR DESCRIPTION
When pretty location generates a location for a namespaced model it should replace '::' with '/'. If this is not done the S3 storage's URI method (given host option is set) attempts to use `URI.join` which does not produce an expected result when the path contains '::'.

```
2.2.3 :001 > require 'uri'
 => true
2.2.3 :002 > URI.join('https://example.com', 'namespaced::openstruct/something.jpg').to_s
 => "namespaced::openstruct/something.jpg"
2.2.3 :003 > URI.join('https://example.com', 'namespaced/openstruct/something.jpg').to_s
 => "https://example.com/namespaced/openstruct/something.jpg"
```

Besides this one could argue that the directory structure should follow the namespacing of the models.

This PR is bit problematic in the sense that for filesystem storage it introduces a breaking change. Then again for the S3 storage it does not break things as the previous implementation simply did not work.

Finally, I'd like to say thank you for this feature packed and yet understandable codebase. I'm new to this library so I may have understood something wrong. The inspiration for the PR came from a real world use case where I had to override the `generate_location` method for an uploader with S3 storage and host option set, attached to a namespaced model so I believe I'm onto something here. Perhaps there's another way around this and as previously stated this PR has its downsides as it can break a functioning default pretty location setup when the storage is filesystem.