### PR TITLE
Fix deprecation warning with implicit S3 credentials

### DIFF
--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -220,7 +220,7 @@ class Shrine
 
       # This is used to check whether an S3 file is copyable.
       def access_key_id
-        @s3.client.config.credentials.access_key_id
+        @s3.client.config.credentials.credentials.access_key_id
       end
 
       private


### PR DESCRIPTION
When S3 credentials are provided then `@s3.client.config.credentials` will be set to an instance of `Aws::Credentials`, which happily responds to `#access_key_id`.

If S3 credentials are not provided explicitly, the aws-sdk gem will search for them in environment variables, ~/.aws/credentials, and by querying the metadata service when running on EC2. In this case, 
`@s3.client.config.credentials` ends up being one of the subclasses of Aws::CredentialProvider. Calling `#access_key_id` on these objects triggers a deprecation warning:

    DEPRECATION WARNING: called deprecated method `access_key_id' of an Aws::CredentialProvider, use #credentials instead

Fortunately, both `Aws::Credentials` and `Aws::CredentialProvider` implement `#credentials`, so this change will work in either case.