### PR TITLE
Rewind IO cursor after failed image dimension extraction by FastImage

### DIFF
--- a/lib/shrine/plugins/store_dimensions.rb
+++ b/lib/shrine/plugins/store_dimensions.rb
@@ -62,7 +62,10 @@ class Shrine
         private
 
         def _extract_dimensions_with_fastimage(io)
-          FastImage.size(io)
+          FastImage.size(io, raise_on_failure: true)
+        rescue FastImage::FastImageException
+          io.rewind
+          nil
         end
       end
 

--- a/test/fixtures/invalid_image.jpg
+++ b/test/fixtures/invalid_image.jpg
@@ -1,0 +1,1 @@
+Invalid image

--- a/test/plugin/store_dimensions_test.rb
+++ b/test/plugin/store_dimensions_test.rb
@@ -21,6 +21,13 @@ describe "the store_dimensions plugin" do
       assert_equal 100, uploaded_file.metadata["width"]
       assert_equal 67, uploaded_file.metadata["height"]
     end
+
+    it "resets cursor after reading attempting to extract dimensions from an invalid image file" do
+      io = File.open("test/fixtures/invalid_image.jpg")
+      @uploader = uploader(:fastimage)
+      uploaded_file = @uploader.extract_dimensions(io)
+      assert_equal 0, io.pos
+    end
   end
 
   it "allows storing with custom extractor" do


### PR DESCRIPTION
I made this PR in bit of haste so please review accordingly.

FastImage gem does not rewind IO cursor if the dimension extraction fails eg. due to providing a non-image file. Non rewinded IO causes S3 upload to fail with Aws::S3::Errors::BadDigest before file can be validated.