### PR TITLE
Fix file command in determine_mime_type plugin

### DIFF
--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -86,7 +86,7 @@ class Shrine
         # if it's a file, because even though the utility accepts standard
         # input, it would mean that we have to read the whole file in memory.
         def _extract_mime_type_with_file(io)
-          cmd = ["file", "--mime-type", "--brief"]
+          cmd = ["file", "--mime-type", "--brief", "--"]
 
           if io.respond_to?(:path)
             mime_type, _ = Open3.capture2(*cmd, io.path)

--- a/test/plugin/determine_mime_type_test.rb
+++ b/test/plugin/determine_mime_type_test.rb
@@ -16,6 +16,24 @@ describe "the determine_mime_type plugin" do
       mime_type = @uploader.send(:extract_mime_type, fakeio(image.read))
       assert_equal "image/jpeg", mime_type
     end
+
+    describe "when the path looks like an option" do
+      let(:path) { "-image.jpg" }
+
+      before do
+        FileUtils.cp(image, path)
+      end
+
+      after do
+        FileUtils.rm(path)
+      end
+
+      it "does not fail and determines content type from file contents" do
+        image = File.open(path)
+        mime_type = @uploader.send(:extract_mime_type, image)
+        assert_equal "image/jpeg", mime_type
+      end
+    end
   end
 
   describe ":filemagic" do


### PR DESCRIPTION
The `file` utility's option parser is greedy and interprets every
argument that begins with a hyphen as an option. This means pathnames
that start with a hyphen cause the command to fail, either by invalid
options or never passing it required input. For example,
`file -image.jpg` looks like combined options and is parsed as `-i`, `-m`,
`-a` (invalid), etc.

To prevent this, `--` is appended to the command to signify the end of
options and allows subsequent arguments to be excluded from option
parsing.

---

Here's [a standalone script](https://gist.github.com/zaeleus/5784e0b966555c5d008ec534ad7b1501) that shows the incorrect behavior.

````
$ wget -O -image.jpg http://i.imgur.com/aDNltvP.jpg
$ wget https://gist.githubusercontent.com/zaeleus/5784e0b966555c5d008ec534ad7b1501/raw/c311f5b098e91eecbe6dc814df57c5bfc839121f/shrine_61.rb
$ ruby shrine_61.rb
Usage: file [-bchikLNnprsvz0] [-e test] [-f namefile] [-F separator] [-m magicfiles] [-M magicfiles] file...
       file -C -m magicfiles
Try `file --help' for more information.
["isn't of allowed type: [\"image/jpeg\"]"]
````