### PR TITLE
pretty_location optional id_partition extracted from paperclip

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,14 @@ photo = Photo.create(image: File.open("nature.jpg"))
 photo.image.id #=> "photo/34/image/34krtreds2df.jpg"
 ```
 
+```rb
+Shrine.plugin :pretty_location, id_partition: true
+```
+```rb
+photo = Photo.create(image: File.open("nature.jpg"))
+photo.image.id #=> "photo/000/000/034/image/34krtreds2df.jpg"
+```
+
 If you want to generate locations on your own, you can override
 `Shrine#generate_location`:
 

--- a/test/plugin/pretty_location_test.rb
+++ b/test/plugin/pretty_location_test.rb
@@ -31,4 +31,16 @@ describe Shrine::Plugins::PrettyLocation do
     uploaded_file = @uploader.upload(fakeio, record: NameSpaced::OpenStruct.new(id: 123), name: :avatar)
     assert_match %r{^namespaced_openstruct/123/avatar/[\w-]+$}, uploaded_file.id
   end
+
+  it "returns the partitioned id of the attachment when the id is an integer" do
+    @uploader.class.plugin :pretty_location, id_partition: true
+    uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(id: 123), name: :avatar)
+    assert_match %r{^openstruct/000/000/123/avatar/[\w-]+$}, uploaded_file.id
+  end
+
+  it "returns the partitioned id of the attachment when the id is a string" do
+    @uploader.class.plugin :pretty_location, id_partition: true
+    uploaded_file = @uploader.upload(fakeio, record: OpenStruct.new(id: '32fnj23oio2f'), name: :avatar)
+    assert_match %r{^openstruct/32f/nj2/3oi/avatar/[\w-]+$}, uploaded_file.id
+  end
 end


### PR DESCRIPTION
Added `id_partition` option to `pretty_location` to be able to shard files between subfolders.

```rb
Shrine.plugin :pretty_location, id_partition: true
```
```rb
photo = Photo.create(image: File.open("nature.jpg"))
photo.image.id #=> "photo/000/000/034/image/34krtreds2df.jpg"
```