### PR TITLE
Preserve filename on download

### DIFF
--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -763,6 +763,7 @@ class Shrine
 
         # Calls `#url` on the storage, forwarding any options.
         def url(**options)
+          options.merge!(shrine_metadata: metadata)
           storage.url(id, **options)
         end
 

--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -237,8 +237,20 @@ class Shrine
       #
       # [`Aws::S3::Object#presigned_url`]: http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Object.html#presigned_url-instance_method
       # [`Aws::S3::Object#public_url`]: http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Object.html#public_url-instance_method
-      def url(id, download: nil, public: nil, host: self.host, **options)
-        options[:response_content_disposition] = "attachment" if download
+      def url(id,
+              download: nil,
+              public: nil,
+              host: self.host,
+              shrine_metadata: nil,
+              **options)
+        options[:response_content_disposition] = if download
+          if shrine_metadata &&
+              filename = shrine_metadata['filename']
+            "attachment; filename=#{filename}"
+          else
+            "attachment"
+          end
+        end
 
         if public
           url = object(id).public_url(**options)

--- a/test/attacher_test.rb
+++ b/test/attacher_test.rb
@@ -246,7 +246,7 @@ describe Shrine::Attacher do
     end
 
     it "forwards options to uploaded file's #url" do
-      @attacher.cache.storage.instance_eval { def url(id, **opts); opts.to_json; end }
+      @attacher.cache.storage.instance_eval { def url(id, shrine_metadata:, **opts); opts.to_json; end }
       @attacher.assign(fakeio)
       assert_equal '{"foo":"bar"}', @attacher.url(foo: "bar")
     end
@@ -254,6 +254,12 @@ describe Shrine::Attacher do
     it "calls #default_url when attachment is missing" do
       @attacher.shrine_class.plugin(:default_url) { |c| c[:foo] }
       assert_equal "bar", @attacher.url(foo: "bar")
+    end
+
+    it "adds the metadata to the method call" do
+      @attacher.cache.storage.instance_eval { def url(id, shrine_metadata:, **opts); shrine_metadata.to_json; end }
+      @attacher.assign(fakeio)
+      assert_equal '{"filename":null,"size":4,"mime_type":null}', @attacher.url
     end
   end
 

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -34,7 +34,7 @@ describe Shrine::Attachment do
     end
 
     it "forwards options to the attacher" do
-      @user.avatar_attacher.cache.storage.instance_eval { def url(id, **o); o.to_json; end }
+      @user.avatar_attacher.cache.storage.instance_eval { def url(id, shrine_metadata:, **o); o.to_json; end }
       @user.avatar = fakeio
       assert_equal '{"foo":"bar"}', @user.avatar_url(foo: "bar")
     end

--- a/test/plugin/default_url_options_test.rb
+++ b/test/plugin/default_url_options_test.rb
@@ -10,19 +10,41 @@ describe Shrine::Plugins::DefaultUrlOptions do
 
   it "adds default options" do
     uploaded_file = @uploader.upload(fakeio)
-    uploaded_file.storage.expects(:url).with(uploaded_file.id, {foo: "foo"})
+    uploaded_file.storage.expects(:url).with(uploaded_file.id, {
+      foo: "foo",
+      shrine_metadata: {
+        'filename' => nil,
+        'size' => 4,
+        'mime_type' => nil
+      }
+    })
     uploaded_file.url
   end
 
   it "merges default options with custom options" do
     uploaded_file = @uploader.upload(fakeio)
-    uploaded_file.storage.expects(:url).with(uploaded_file.id, {foo: "foo", bar: "bar"})
+    uploaded_file.storage.expects(:url).with(uploaded_file.id, {
+      foo: "foo",
+      bar: "bar",
+      shrine_metadata: {
+        'filename' => nil,
+        'size' => 4,
+        'mime_type' => nil
+      }
+    })
     uploaded_file.url(bar: "bar")
   end
 
   it "allows custom options to override default options" do
     uploaded_file = @uploader.upload(fakeio)
-    uploaded_file.storage.expects(:url).with(uploaded_file.id, {foo: "overriden"})
+    uploaded_file.storage.expects(:url).with(uploaded_file.id, {
+      foo: "overriden",
+      shrine_metadata: {
+        'filename' => nil,
+        'size' => 4,
+        'mime_type' => nil
+      }
+    })
     uploaded_file.url(foo: "overriden")
   end
 end

--- a/test/s3_test.rb
+++ b/test/s3_test.rb
@@ -101,6 +101,13 @@ describe Shrine::Storage::S3 do
       assert_match "response-content-disposition=attachment", url
     end
 
+    it "preserves the filename on a force download URL" do
+      @s3.upload(fakeio("image"), "foo")
+      url = @s3.url("foo", shrine_metadata: {'filename' => 'foo'}, download: true)
+      puts url
+      assert_match "response-content-disposition=attachment%3B%20filename%3Dfoo", url
+    end
+
     it "can provide a CDN url" do
       url = s3.url("foo/bar quux", host: "http://123.cloudfront.net")
       assert_match "http://123.cloudfront.net/foo/bar%20quux", url

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -212,7 +212,10 @@ describe Shrine::UploadedFile do
 
     it "forwards given options to storage" do
       uploaded_file = uploaded_file("id" => "foo")
-      uploaded_file.storage.expects(:url).with("foo", {foo: "foo"})
+      uploaded_file.storage.expects(:url).with("foo", {
+        foo: "foo",
+        shrine_metadata: {}
+      })
       uploaded_file.url(foo: "foo")
     end
   end


### PR DESCRIPTION
Also set the filename in `Content-Disposition` header on forced download links. 