### PR TITLE
Add dot to file extension when missing

### DIFF
--- a/lib/shrine/plugins/direct_upload.rb
+++ b/lib/shrine/plugins/direct_upload.rb
@@ -251,7 +251,10 @@ class Shrine
           if presign_location
             presign_location.call(request)
           else
-            uploader.send(:generate_uid, nil) + request.params["extension"].to_s
+            extension = request.params["extension"].to_s
+            extension = ".#{extension}" \
+              if extension.present? && !extension.starts_with?('.')
+            uploader.send(:generate_uid, nil) + extension
           end
         end
 


### PR DESCRIPTION
Currently, you have to request the presigned POST with something like `...?extension=.jpg`. It would be nice to be able to drop the dot, i.e. `...?extension=jpg`.