### PR TITLE
Validate extensions case insensitive

### DIFF
--- a/lib/shrine/plugins/validation_helpers.rb
+++ b/lib/shrine/plugins/validation_helpers.rb
@@ -150,7 +150,7 @@ class Shrine
 
         # Converts a string to a regex.
         def regex(value)
-          value.is_a?(Regexp) ? value : /\A#{Regexp.escape(value)}\z/
+          value.is_a?(Regexp) ? value : /\A#{Regexp.escape(value)}\z/i
         end
 
         # Returns the direct message if given, otherwise uses the default error


### PR DESCRIPTION
If we have `jpg` in the whitelist it would make sense to accept `JPG` as well. 