### PR TITLE
Overwrite existing metadata on S3

### DIFF
--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -302,6 +302,13 @@ class Shrine
 
       # Copies an existing S3 object to a new location.
       def copy(io, id, **options)
+        options[:metadata_directive] = 'REPLACE'
+        existing_metadata = object(io.id).metadata
+        options[:metadata] ||= {}
+        options[:metadata].merge!(existing_metadata) { |_, new_value, _|
+          new_value
+        }
+
         options = {multipart_copy: true, content_length: io.size}.update(options) if multipart?(io)
         object(id).copy_from(io.storage.object(io.id), **options)
       end


### PR DESCRIPTION
This is especially useful for `Content-Type`. S3 sets this to `application/octet-stream` by default. So when you use the `direct_upload` plugin (and don't let the presign endpoint take the mime type) files uploaded directly to the cache in S3 will always have this content type. 
The AWS S3 cli does not overwrite metadata by default, only when told so via `metadata_directive`.  This is what this PR aims to do. 

But if you set `metadata_directive` to `'REPLACE'` no metadata is copied at all. So you need to fetch the old metadata and merge it into the new metadata. 

Unfortunately, it seems like `metadata_directive` influences the behaviour when updating e.g. `content_type`, but `Object#metadata` only includes metadata of the form `x-amz-meta-*`. So we might loose some metadata like `content_encoding`. I'm not completely sure how to solve this yet. 