### PR TITLE
Fix typo in Plugins::MetadataAttributes docs

### DIFF
--- a/lib/shrine/plugins/metadata_attributes.rb
+++ b/lib/shrine/plugins/metadata_attributes.rb
@@ -3,7 +3,7 @@ class Shrine
     # The `metadata_attributes` plugin allows you to sync attachment metadata
     # to additional record attributes.
     #
-    #     plugin :metadata_values
+    #     plugin :metadata_attributes
     #
     # It provides `Attacher.metadata_attributes` method which allows you to
     # specify mappings between metadata fields on the attachment and attribute


### PR DESCRIPTION
This PR doesn't really propose any significant changes. At all. 

So I was reading docs on the [MetadataAttribbutes plugin](http://shrinerb.com/rdoc/classes/Shrine/Plugins/MetadataAttributes.html). 
The docs said ```plugin :metadata_values```. 
Decided to try it out... Yup. 

```
LoadError:
       cannot load such file -- shrine/plugins/metadata_values
```

Replacing `metadata_values` with `metadata_attributes` did the job.

Checked docs for other plugins (listed at shrinerb.org). Everything else seems okay.