### PR TITLE
Accept Attacher options via Attachment.new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * Don't add a newline at the end of the base64-formatted signature (@janko-m)
 
+* Accept `Attacher.new` options like `store:` and `cache:` via `Attachment.new` (@ypresto)
+
 ## 2.6.1 (2017-04-12)
 
 * Fix `download_endpoint` returning incorrect reponse body in some cases (@janko-m)

--- a/doc/attacher.md
+++ b/doc/attacher.md
@@ -40,6 +40,14 @@ also tell it to use different temporary and permanent storage:
 ImageUploader::Attacher.new(photo, :image, cache: :other_cache, store: :other_store)
 ```
 
+Note that you can pass `Attacher.new` options via `Attachment.new` too:
+
+```rb
+class Photo < Sequel::Model
+  include ImageUploader::Attachment.new(:image, cache: :other_cache, store: :other_store)
+end
+```
+
 The attacher will use the `<attachment>_data` attribute for storing information
 about the attachment.
 

--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -154,8 +154,8 @@ class Shrine
         #     class Photo
         #       include Shrine.attachment(:image) # creates a Shrine::Attachment object
         #     end
-        def attachment(name)
-          self::Attachment.new(name)
+        def attachment(name, options = nil)
+          self::Attachment.new(name, options)
         end
         alias [] attachment
 
@@ -389,17 +389,19 @@ class Shrine
 
       module AttachmentMethods
         # Instantiates an attachment module for a given attribute name, which
-        # can then be included to a model class.
-        def initialize(name)
+        # can then be included to a model class. Second argument will be passed
+        # to an attacher module.
+        def initialize(name, options = nil)
           @name = name
 
           # We store the attacher class so that the model can instantiate the
           # correct attacher instance.
           class_variable_set(:"@@#{name}_attacher_class", shrine_class::Attacher)
+          class_variable_set(:"@@#{name}_attacher_options", options || {})
 
           module_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{name}_attacher
-              @#{name}_attacher ||= @@#{name}_attacher_class.new(self, :#{name})
+              @#{name}_attacher ||= @@#{name}_attacher_class.new(self, :#{name}, **@@#{name}_attacher_options)
             end
 
             def #{name}=(value)

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -59,4 +59,10 @@ describe Shrine::Attachment do
       assert_match "Attachment(avatar)", @user.class.ancestors[1].inspect
     end
   end
+
+  it "passes options to attacher" do
+    user = attacher(attachment_options: { store: :cache, cache: :store }).record
+    assert_equal :cache, user.avatar_attacher.store.storage_key
+    assert_equal :store, user.avatar_attacher.cache.storage_key
+  end
 end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -12,11 +12,11 @@ module TestHelpers
       uploader_class.new(storage_key)
     end
 
-    def attacher(*args, &block)
+    def attacher(*args, attachment_options: nil, &block)
       uploader = uploader(*args, &block)
       Object.send(:remove_const, "User") if defined?(User) # for warnings
       user_class = Object.const_set("User", Struct.new(:avatar_data, :id))
-      user_class.include uploader.class::Attachment.new(:avatar)
+      user_class.include uploader.class::Attachment.new(:avatar, attachment_options)
       user_class.new.avatar_attacher
     end
 


### PR DESCRIPTION
I wrote below snippet to pass `store:` and `cache:` args to Attacher but it did not work.

```rb
include ImageUploader::Attachment.new(:file, store: :private_store, cache: :private_cache)
```

So I implemented it..!