### PR TITLE
Fix mime_type on empty file causes TypeError or unexpected value

### DIFF
--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -142,7 +142,12 @@ class Shrine
           require "open3"
 
           cmd = ["file", "--mime-type", "--brief", "-"]
-          options = {stdin_data: io.read(MAGIC_NUMBER), binmode: true}
+          buffer = io.read(MAGIC_NUMBER)
+          # Emulate behavior of file command:
+          # $ file test/fixtures/empty
+          # test/fixtures/empty: empty
+          return "empty" if buffer.nil?
+          options = {stdin_data: buffer, binmode: true}
 
           begin
             stdout, stderr, status = Open3.capture3(*cmd, options)
@@ -160,7 +165,7 @@ class Shrine
           require "filemagic"
 
           filemagic = FileMagic.new(FileMagic::MAGIC_MIME_TYPE)
-          mime_type = filemagic.buffer(io.read(MAGIC_NUMBER))
+          mime_type = filemagic.buffer(io.read(MAGIC_NUMBER) || '')
           filemagic.close
 
           mime_type

--- a/test/plugin/determine_mime_type_test.rb
+++ b/test/plugin/determine_mime_type_test.rb
@@ -14,6 +14,11 @@ describe Shrine::Plugins::DetermineMimeType do
       assert_equal "image/jpeg", mime_type
     end
 
+    it "returns 'empty' for empty file" do
+      mime_type = @uploader.send(:extract_mime_type, empty_file)
+      assert_equal "empty", mime_type
+    end
+
     it "is able to determine MIME type for non-files" do
       mime_type = @uploader.send(:extract_mime_type, fakeio(image.read))
       assert_equal "image/jpeg", mime_type
@@ -48,6 +53,11 @@ describe Shrine::Plugins::DetermineMimeType do
       mime_type = @uploader.send(:extract_mime_type, image)
       assert_equal "image/jpeg", mime_type
     end
+
+    it "returns 'x-empty' for empty file" do
+      mime_type = @uploader.send(:extract_mime_type, empty_file)
+      assert_equal "application/x-empty", mime_type
+    end
   end unless RUBY_ENGINE == "jruby" || ENV["CI"]
 
   describe ":mimemagic analyzer" do
@@ -58,6 +68,11 @@ describe Shrine::Plugins::DetermineMimeType do
     it "extracts MIME type of any IO" do
       mime_type = @uploader.send(:extract_mime_type, image)
       assert_equal "image/jpeg", mime_type
+    end
+
+    it "returns nil for empty file" do
+      mime_type = @uploader.send(:extract_mime_type, empty_file)
+      assert_nil mime_type
     end
 
     it "returns nil for unidentified MIME types" do

--- a/test/support/generic_helper.rb
+++ b/test/support/generic_helper.rb
@@ -32,6 +32,10 @@ class Minitest::HooksSpec
     File.open("test/fixtures/image.jpg")
   end
 
+  def empty_file
+    File.open("test/fixtures/empty")
+  end
+
   def io?(object)
     missing_methods = Shrine::IO_METHODS.reject do |m, a|
       object.respond_to?(m) && [a.count, -1].include?(object.method(m).arity)


### PR DESCRIPTION
When empty file is passed to determine_mime_type plugin,

- `:file` analyzer will return `"cannot open: No such file or directory"` for mime type string.
- `:filemagic` will raise TypeError, which is caused by passing nil to `filemagic.buffer()`.

This PR fixes it..!

(filemagic one causes SEGV when gcc is used >_< https://github.com/blackwinter/ruby-filemagic/pull/24 )