### PR TITLE
Fix styling issues following github-rubocop rules

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ Rake::TestTask.new do |t|
   t.warning = false
 end
 
-task :default => :test
+task default: :test
 
 RDoc::Task.new do |t|
   t.rdoc_dir = "www/build/rdoc"
@@ -29,7 +29,7 @@ RDoc::Task.new do |t|
   ]
 end
 
-task :rdoc => "website:rdoc_github_links"
+task rdoc: "website:rdoc_github_links"
 
 namespace :website do
   task :build do

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -4,16 +4,15 @@ source "https://rubygems.org"
 gem "puma"
 gem "roda", "~> 2.15"
 gem "tilt"
-gem "rack_csrf"
 
 # Database
 gem "sequel"
 gem "sqlite3"
 
 # Attachments
-gem "shrine", path: ".."
 gem "aws-sdk-s3", "~> 1.2"
 gem "dotenv"
+gem "shrine", path: ".."
 
 # Processing
 gem "image_processing"

--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -28,11 +28,11 @@ class Shrine
   # Methods which an object has to respond to in order to be considered
   # an IO object, along with their arguments.
   IO_METHODS = {
-    :read   => [:length, :outbuf],
-    :eof?   => [],
-    :rewind => [],
-    :size   => [],
-    :close  => [],
+    read:   [:length, :outbuf],
+    eof?:   [],
+    rewind: [],
+    size:   [],
+    close:  [],
   }
 
   # Core class that represents a file uploaded to a storage. The instance

--- a/lib/shrine/plugins/default_url.rb
+++ b/lib/shrine/plugins/default_url.rb
@@ -50,7 +50,7 @@ class Shrine
           if default_url_block
             instance_exec(options, &default_url_block)
           elsif shrine_class.opts[:default_url]
-            shrine_class.opts[:default_url].call(context.merge(options){|k,old,new|old})
+            shrine_class.opts[:default_url].call(context.merge(options){|k, old, new| old})
           end
         end
 

--- a/lib/shrine/plugins/direct_upload.rb
+++ b/lib/shrine/plugins/direct_upload.rb
@@ -258,7 +258,7 @@ class Shrine
             presign_location.call(request)
           else
             extension = request.params["extension"]
-            extension.prepend(".") if extension && !extension.start_with?('.')
+            extension.prepend(".") if extension && !extension.start_with?(".")
             uploader.send(:generate_uid, nil) + extension.to_s
           end
         end

--- a/lib/shrine/version.rb
+++ b/lib/shrine/version.rb
@@ -9,6 +9,6 @@ class Shrine
     TINY  = 0
     PRE   = nil
 
-    STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
+    STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
   end
 end

--- a/test/file_system_test.rb
+++ b/test/file_system_test.rb
@@ -71,7 +71,7 @@ describe Shrine::Storage::FileSystem do
     it "copies full file content" do
       @storage.upload(input = fakeio("A" * 20_000), "foo.jpg")
       assert_equal 20_000, @storage.open("foo.jpg").size
-   end
+    end
 
     it "sets file permissions" do
       @storage = file_system(root, permissions: 0600)
@@ -116,7 +116,7 @@ describe Shrine::Storage::FileSystem do
 
       @storage.move(file, "foo")
       assert @storage.exists?("foo")
-      refute File.exists?(file.path)
+      refute File.exist?(file.path)
 
       @storage.move(uploaded_file, "bar")
       assert @storage.exists?("bar")

--- a/test/linter_test.rb
+++ b/test/linter_test.rb
@@ -173,7 +173,7 @@ describe Shrine::Storage::Linter do
   end
 
   it "doesn't pass any file extensions" do
-    @storage.instance_eval { def upload(io, id, *); raise if id.include?('.'); super; end }
+    @storage.instance_eval { def upload(io, id, *); raise if id.include?("."); super; end }
     @linter.call
   end
 end

--- a/test/plugin/default_storage_test.rb
+++ b/test/plugin/default_storage_test.rb
@@ -8,7 +8,7 @@ describe Shrine::Plugins::DefaultStorage do
   end
 
   it "allows setting the cache as a block" do
-    @attacher = attacher { plugin :default_storage, cache: ->(record,name){:store} }
+    @attacher = attacher { plugin :default_storage, cache: ->(record, name){:store} }
     assert_equal :store, @attacher.cache.storage_key
   end
 
@@ -18,7 +18,7 @@ describe Shrine::Plugins::DefaultStorage do
   end
 
   it "allows setting the store as a block" do
-    @attacher = attacher { plugin :default_storage, store: ->(record,name){:cache} }
+    @attacher = attacher { plugin :default_storage, store: ->(record, name){:cache} }
     assert_equal :cache, @attacher.store.storage_key
   end
 end

--- a/test/plugin/direct_upload_test.rb
+++ b/test/plugin/direct_upload_test.rb
@@ -32,10 +32,10 @@ describe Shrine::Plugins::DirectUpload do
 
     it "assigns metadata" do
       response = app.post "/cache/upload", multipart: {file: image}
-      metadata = response.body_json.fetch('metadata')
-      assert_equal 'image.jpg', metadata['filename']
-      assert_equal 'image/jpeg', metadata['mime_type']
-      assert_kind_of Integer, metadata['size']
+      metadata = response.body_json.fetch("metadata")
+      assert_equal "image.jpg", metadata["filename"]
+      assert_equal "image/jpeg", metadata["mime_type"]
+      assert_kind_of Integer, metadata["size"]
     end
 
     it "serializes uploaded hashes and arrays as well" do
@@ -43,7 +43,7 @@ describe Shrine::Plugins::DirectUpload do
 
       @uploader.class.class_eval { define_method(:upload) { |*| Hash[thumb: uploaded_file] } }
       response = app.post "/cache/upload", multipart: {file: image}
-      refute_empty response.body_json.fetch('thumb')
+      refute_empty response.body_json.fetch("thumb")
 
       @uploader.class.class_eval { define_method(:upload) { |*| Array[uploaded_file] } }
       response = app.post "/cache/upload", multipart: {file: image}

--- a/test/plugin/metadata_attributes_test.rb
+++ b/test/plugin/metadata_attributes_test.rb
@@ -8,7 +8,7 @@ describe Shrine::Plugins::MetadataAttributes do
 
   it "writes values to metadata attributes when file is assigned" do
     @attacher.record.singleton_class.instance_eval { attr_accessor :avatar_size, :avatar_type }
-    @attacher.class.metadata_attributes :size => :size, :mime_type => :type
+    @attacher.class.metadata_attributes size: :size, mime_type: :type
     @attacher.assign(fakeio("file", content_type: "text/plain"))
     assert_equal 4,            @attacher.record.avatar_size
     assert_equal "text/plain", @attacher.record.avatar_type
@@ -16,7 +16,7 @@ describe Shrine::Plugins::MetadataAttributes do
 
   it "set metadata attributes to nil when file is removed" do
     @attacher.record.singleton_class.instance_eval { attr_accessor :avatar_size, :avatar_type }
-    @attacher.class.metadata_attributes :size => :size, :mime_type => :type
+    @attacher.class.metadata_attributes size: :size, mime_type: :type
     @attacher.assign(fakeio("file", content_type: "text/plain"))
     @attacher.assign(nil)
     assert_nil @attacher.record.avatar_size
@@ -42,7 +42,7 @@ describe Shrine::Plugins::MetadataAttributes do
 
   it "doesn't raise errors if metadata attribute is missing" do
     @attacher.record.singleton_class.instance_eval { attr_accessor :avatar_size }
-    @attacher.class.metadata_attributes :size => :size, :mime_type => :type
+    @attacher.class.metadata_attributes size: :size, mime_type: :type
     @attacher.assign(fakeio("file", content_type: "text/plain"))
     assert_equal 4, @attacher.record.avatar_size
   end

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -385,14 +385,14 @@ describe Shrine::UploadedFile do
   end
 
   it "implements equality" do
-    assert_equal uploaded_file(), uploaded_file()
+    assert_equal uploaded_file, uploaded_file
     assert_equal uploaded_file("metadata" => {"foo" => "foo"}), uploaded_file("metadata" => {"bar" => "bar"})
     refute_equal uploaded_file("id" => "foo"), uploaded_file("id" => "bar")
     refute_equal uploaded_file("storage" => "store"), uploaded_file("storage" => "cache")
   end
 
   it "implements hash equality" do
-    assert_equal 1, Set.new([uploaded_file(), uploaded_file()]).size
+    assert_equal 1, Set.new([uploaded_file, uploaded_file]).size
     assert_equal 2, Set.new([uploaded_file("id" => "foo"), uploaded_file("id" => "bar")]).size
     assert_equal 2, Set.new([uploaded_file("storage" => "store"), uploaded_file("storage" => "cache")]).size
   end

--- a/www/Gemfile
+++ b/www/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'github-pages', '>= 39'
+gem "github-pages", ">= 39"


### PR DESCRIPTION
Just started the process to move from Carrierwave to Shrine [@GoodGym](www.goodgym.org) (Great work btw :+1: ), and notice some old 1.9 ruby Syntax in the docs and code.

So I thought it could be nice to enforce new version ruby style.

One of the best way to to it is to use [rubocop](https://github.com/bbatsov/rubocop) and [github version of it](https://github.com/github/rubocop-github) which follow [Ruby community style guide](https://github.com/bbatsov/ruby-style-guide), and keeping this gem up-to-date will permit to stay in sync with the style when moving to newer version

One exception which I was unsure was `AllowAsExpressionSeparator` which was complaining about following example with inline semi column: 
`@uploader.class.add_metadata { |io, context| io.read; nil }` 
or 
`@storage.instance_eval { def upload(io, id, *); super; io.close; end }`

[Here](https://gist.github.com/manzan46/3372c14c6b3fc841989ea24b210c710f) is a list of all original complain of rubocop

Keep it up the good work