### PR TITLE
From carrierwave typo in Storage model name

### DIFF
--- a/doc/carrierwave.md
+++ b/doc/carrierwave.md
@@ -39,8 +39,8 @@ via [direct uploads]):
 
 ```rb
 Shrine.storages = {
-  cache: Shrine::Storages::S3.new(prefix: "cache", **s3_options),
-  store: Shrine::Storages::S3.new(prefix: "store", **s3_options),
+  cache: Shrine::Storage::S3.new(prefix: "cache", **s3_options),
+  store: Shrine::Storage::S3.new(prefix: "store", **s3_options),
 }
 ```
 


### PR DESCRIPTION
A small typo in the Moving from Carrierwave doc

```rb
Shrine.storages = {
  cache: Shrine::Storage::S3.new(prefix: "cache", **s3_options),
  store: Shrine::Storage::S3.new(prefix: "store", **s3_options),
}
```
instead of 
```rb
Shrine.storages = {
  cache: Shrine::Storages::S3.new(prefix: "cache", **s3_options),
  store: Shrine::Storages::S3.new(prefix: "store", **s3_options),
}
```