### PR TITLE
Custom attacher options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Allow specifying custom attacher options (@arg)
+
 * Modify `UploadedFile#extension` to always return the extension in lowercase format (@janko-m)
 
 * Downcase the original file extension when generating an upload location (@janko-m)

--- a/doc/attacher.md
+++ b/doc/attacher.md
@@ -27,10 +27,11 @@ attacher.get                                          # equivalent to `photo.ima
 The attacher object exposes the objects it uses:
 
 ```rb
-attacher.record #=> #<Photo>
-attacher.name   #=> :image
-attacher.cache  #=> #<ImageUploader @storage_key=:cache>
-attacher.store  #=> #<ImageUploader @storage_key=:store>
+attacher.record  #=> #<Photo>
+attacher.name    #=> :image
+attacher.cache   #=> #<ImageUploader @storage_key=:cache>
+attacher.store   #=> #<ImageUploader @storage_key=:store>
+attacher.options #=> custom attacher options
 ```
 
 The attacher will automatically use `:cache` and `:store` storages, but you can

--- a/doc/design.md
+++ b/doc/design.md
@@ -206,4 +206,13 @@ automatically:
 * deletes the uploaded file if attachment was replaced/removed or the record
   destroyed
 
+You can pass options to `Shrine::Attacher` (including `cache` and `store` override)
+by specifying them as arguments of `Shrine::Attachment.new`:
+
+```rb
+class Photo
+  include Shrine::Attachment.new(:image, cache: :storage_1, store: :storage_2, max_upload_size: 1.megabyte)
+end
+```
+
 [Using Attacher]: http://shrinerb.com/rdoc/files/doc/attacher_md.html

--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -494,10 +494,14 @@ class Shrine
         # the `Attacher.validate` block.
         attr_reader :errors
 
+        # Returns options passed to Attacher
+        attr_reader :options
+
         # Initializes the necessary attributes.
-        def initialize(record, name, cache: :cache, store: :store)
-          @cache   = shrine_class.new(cache)
-          @store   = shrine_class.new(store)
+        def initialize(record, name, **options)
+          @options  = options
+          @cache   = shrine_class.new(options.fetch(:cache, :cache))
+          @store   = shrine_class.new(options.fetch(:store, :store))
           @context = {record: record, name: name}
           @errors  = []
         end

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -60,9 +60,21 @@ describe Shrine::Attachment do
     end
   end
 
-  it "passes options to attacher" do
-    user = attacher(attachment_options: { store: :cache, cache: :store }).record
-    assert_equal :cache, user.avatar_attacher.store.storage_key
-    assert_equal :store, user.avatar_attacher.cache.storage_key
+  describe 'Attacher options' do
+    it 'sets default cache and store options if not specified' do
+      assert_equal :store, @user.avatar_attacher.store.storage_key
+      assert_equal :cache, @user.avatar_attacher.cache.storage_key
+    end
+
+    it 'correctly sets cache and store options passed to attacher' do
+      user = attacher(attachment_options: { cache: :store, store: :cache }).record
+      assert_equal :store, user.avatar_attacher.cache.storage_key
+      assert_equal :cache, user.avatar_attacher.store.storage_key
+    end
+
+    it 'stores any custom options passed to attacher' do
+      user = attacher(attachment_options: { option: :value }).record
+      assert_equal({ option: :value }, user.avatar_attacher.options)
+    end
   end
 end


### PR DESCRIPTION
This was partially implemented in https://github.com/janko-m/shrine/pull/167, but `Attacher` class crashes if we pass any options other then `cache` and `store`.

```ruby
class Image < ActiveRecord::Base
  include Shrine[:asset, max_upload_size: 1.megabyte] # will crash with "unknown keyword: max_upload_size" message
  ...
end
```

### Why do we need this?

In our app there are few different models having the same `Shrine::Attachment` module included. The only attachment module would totally fit our needs but we'd like to have ability to customize it (e.g specify different validation options like maximum file size or so) in each model. It's not possible with the current Shrine implementation, we have to inherit several attachment classes from our base instead.

With the proposed improvement we will be able to have only one attachment class, customizing it for each model:

```ruby
class Image < ActiveRecord::Base
  include Attachment[:asset, max_file_size: 5.megabytes]
  ...
end

class User < ActiveRecord::Base
  include Attachment[:avatar, max_file_size: 1.megabyte]
  ...
end

class Attachment < Shrine
  ...
  Attacher.validate do
    validate_max_size(options[:max_file_size])
  end
  ...
end
```