### PR TITLE
Delete tempfile if error occurs during download.

### DIFF
--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -803,9 +803,9 @@ class Shrine
               tempfile = Tempfile.new(["shrine", ".#{extension}"], binmode: true)
               open(*args) { |io| IO.copy_stream(io, tempfile.path) }
               tempfile.tap(&:open)
-            rescue => err
+            rescue
               tempfile.close!
-              raise err
+              raise
             end
           end
         end

--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -799,9 +799,14 @@ class Shrine
           if storage.respond_to?(:download)
             storage.download(id, *args)
           else
-            tempfile = Tempfile.new(["shrine", ".#{extension}"], binmode: true)
-            open(*args) { |io| IO.copy_stream(io, tempfile.path) }
-            tempfile.tap(&:open)
+            begin
+              tempfile = Tempfile.new(["shrine", ".#{extension}"], binmode: true)
+              open(*args) { |io| IO.copy_stream(io, tempfile.path) }
+              tempfile.tap(&:open)
+            rescue => err
+              tempfile.close!
+              raise err
+            end
           end
         end
 

--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -804,7 +804,7 @@ class Shrine
               open(*args) { |io| IO.copy_stream(io, tempfile.path) }
               tempfile.tap(&:open)
             rescue
-              tempfile.close!
+              tempfile.close! if tempfile
               raise
             end
           end

--- a/lib/shrine/storage/file_system.rb
+++ b/lib/shrine/storage/file_system.rb
@@ -208,9 +208,9 @@ class Shrine
             tempfile = Tempfile.new(["shrine-filesystem", File.extname(args[0])], binmode: true)
             open(*args) { |file| IO.copy_stream(file, tempfile) }
             tempfile.tap(&:open)
-          rescue => err
+          rescue
             tempfile.close!
-            raise err
+            raise
           end
         else
           super

--- a/lib/shrine/storage/file_system.rb
+++ b/lib/shrine/storage/file_system.rb
@@ -203,10 +203,15 @@ class Shrine
       # Catches the deprecated `#download` method.
       def method_missing(name, *args)
         if name == :download
-          Shrine.deprecation("Shrine::Storage::FileSystem#download is deprecated and will be removed in Shrine 3.")
-          tempfile = Tempfile.new(["shrine-filesystem", File.extname(args[0])], binmode: true)
-          open(*args) { |file| IO.copy_stream(file, tempfile) }
-          tempfile.tap(&:open)
+          begin
+            Shrine.deprecation("Shrine::Storage::FileSystem#download is deprecated and will be removed in Shrine 3.")
+            tempfile = Tempfile.new(["shrine-filesystem", File.extname(args[0])], binmode: true)
+            open(*args) { |file| IO.copy_stream(file, tempfile) }
+            tempfile.tap(&:open)
+          rescue => err
+            tempfile.close!
+            raise err
+          end
         else
           super
         end

--- a/lib/shrine/storage/file_system.rb
+++ b/lib/shrine/storage/file_system.rb
@@ -209,7 +209,7 @@ class Shrine
             open(*args) { |file| IO.copy_stream(file, tempfile) }
             tempfile.tap(&:open)
           rescue
-            tempfile.close!
+            tempfile.close! if tempfile
             raise
           end
         else

--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -253,14 +253,14 @@ class Shrine
       #
       # [`Aws::S3::Object#get`]: http://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Object.html#get-instance_method
       def download(id, **options)
-        tempfile = Tempfile.new(["shrine-s3", File.extname(id)], binmode: true)
         begin
+          tempfile = Tempfile.new(["shrine-s3", File.extname(id)], binmode: true)
           (object = object(id)).get(response_target: tempfile, **options)
           tempfile.singleton_class.instance_eval { attr_accessor :content_type }
           tempfile.content_type = object.content_type
           tempfile.tap(&:open)
         rescue
-          tempfile.close!
+          tempfile.close! if tempfile
           raise
         end
       end

--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -259,9 +259,9 @@ class Shrine
           tempfile.singleton_class.instance_eval { attr_accessor :content_type }
           tempfile.content_type = object.content_type
           tempfile.tap(&:open)
-        rescue => err
+        rescue
           tempfile.close!
-          raise err
+          raise
         end
       end
 

--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -254,10 +254,15 @@ class Shrine
       # [`Aws::S3::Object#get`]: http://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Object.html#get-instance_method
       def download(id, **options)
         tempfile = Tempfile.new(["shrine-s3", File.extname(id)], binmode: true)
-        (object = object(id)).get(response_target: tempfile, **options)
-        tempfile.singleton_class.instance_eval { attr_accessor :content_type }
-        tempfile.content_type = object.content_type
-        tempfile.tap(&:open)
+        begin
+          (object = object(id)).get(response_target: tempfile, **options)
+          tempfile.singleton_class.instance_eval { attr_accessor :content_type }
+          tempfile.content_type = object.content_type
+          tempfile.tap(&:open)
+        rescue => err
+          tempfile.close!
+          raise err
+        end
       end
 
       # Returns a `Down::ChunkedIO` object representing the S3 object. Any

--- a/test/file_system_test.rb
+++ b/test/file_system_test.rb
@@ -290,7 +290,7 @@ describe Shrine::Storage::FileSystem do
     deprecated "#download deletes the Tempfile if there's an error in downloading the file" do
       @storage.instance_eval { def open(id, &block); raise SystemCallError, "error occurred"; end }
       @storage.upload(fakeio, "foo.jpg")
-      Tempfile.stub(:new, tempfile = Tempfile.new) do
+      Tempfile.stub(:new, tempfile = Tempfile.new("foo")) do
         assert_raises(SystemCallError) { @storage.download("foo.jpg") }
       end
       assert tempfile.closed?

--- a/test/s3_test.rb
+++ b/test/s3_test.rb
@@ -229,7 +229,7 @@ describe Shrine::Storage::S3 do
 
     it "deletes the Tempfile if there's an error in downloading the file" do
       io_error = ->(response_target) { raise IOError }
-      Tempfile.stub(:new, tempfile = Tempfile.new) do
+      Tempfile.stub(:new, tempfile = Tempfile.new("foo")) do
         s3_object = @s3.object("foo")
         @s3.stub(:object, s3_object) do
           s3_object.stub(:get, io_error) do

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -321,7 +321,7 @@ describe Shrine::UploadedFile do
 
     it "deletes the Tempfile if there's an error in downloading the file (Shrine class level)" do
       @uploader.storage.instance_eval { undef download }
-      Tempfile.stub(:new, tempfile = Tempfile.new) do
+      Tempfile.stub(:new, tempfile = Tempfile.new("foo")) do
         assert_raises(KeyError) { uploaded_file.download }
       end
       assert tempfile.closed?

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -319,6 +319,23 @@ describe Shrine::UploadedFile do
       assert_match "file", uploaded_file.download.read
     end
 
+    it "deletes the Tempfile if there's an error in downloading the file (Shrine class level)" do
+      io_error = ->(src, dest) { raise IOError }
+      mock = Minitest::Mock.new
+      mock.expect(:close!, nil)
+      def mock.path
+        "some_path"
+      end
+      @uploader.storage.instance_eval { undef download }
+      uploaded_file = @uploader.upload(fakeio("file"))
+      Tempfile.stub(:new, mock) do
+        IO.stub(:copy_stream, io_error) do
+          assert_raises(IOError) { uploaded_file.download }
+        end
+      end
+      mock.verify
+    end
+
     it "uses extension from #id" do
       @uploader.storage.instance_eval { undef download }
       uploaded_file = @uploader.upload(fakeio, location: "foo.jpg")


### PR DESCRIPTION
This addresses the issue of ensuring tempfiles are cleared in the event an error occurs during download in base, S3, and FileSystem modules. Implementation is straightforward like we discussed, the challenge was in testing. 