### PR TITLE
Include CHANGELOG.md in the packaged gem

### DIFF
--- a/shrine.gemspec
+++ b/shrine.gemspec
@@ -23,7 +23,7 @@ direct uploads for fully asynchronous user experience.
   gem.email        = ["janko.marohnic@gmail.com"]
   gem.license      = "MIT"
 
-  gem.files        = Dir["README.md", "LICENSE.txt", "lib/**/*.rb", "shrine.gemspec", "doc/*.md"]
+  gem.files        = Dir["README.md", "LICENSE.txt", "CHANGELOG.md", "lib/**/*.rb", "shrine.gemspec", "doc/*.md"]
   gem.require_path = "lib"
 
   gem.add_dependency "down", "~> 4.1"


### PR DESCRIPTION
As a heavy user of `bundle open` I really appreciate it if the CHANGELOG is part of the gem.