### PR TITLE
Passing a block to Shrine::UploadedFile#open is now optional.

### DIFF
--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -788,11 +788,13 @@ class Shrine
         def open(*args)
           return to_io unless block_given?
 
-          @io = storage.open(id, *args)
-          yield @io
-        ensure
-          @io.close if @io
-          @io = nil
+          begin
+            @io = storage.open(id, *args)
+            yield @io
+          ensure
+            @io.close if @io
+            @io = nil
+          end
         end
 
         # Calls `#download` on the storage if the storage implements it,

--- a/lib/shrine.rb
+++ b/lib/shrine.rb
@@ -778,14 +778,16 @@ class Shrine
         end
         alias content_type mime_type
 
-        # Opens an IO object of the uploaded file for reading and yields it to
-        # the block, closing it after the block finishes. For opening without
-        # a block #to_io can be used.
+        # Opens an IO object of the uploaded file for reading, yields it to
+        # the block, and closes it after the block finishes. If opening without
+        # a block, it returns an opened IO object for the uploaded file.
         #
         #     uploaded_file.open do |io|
         #       puts io.read # prints the content of the file
         #     end
         def open(*args)
+          return to_io unless block_given?
+
           @io = storage.open(id, *args)
           yield @io
         ensure

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -235,7 +235,13 @@ describe Shrine::UploadedFile do
   end
 
   describe "#open" do
-    it "yields to the block" do
+    it "returns the underlying IO if no block given" do
+      uploaded_file = @uploader.upload(fakeio)
+      assert io?(uploaded_file.open)
+      assert_equal uploaded_file.object_id, uploaded_file.object_id
+    end
+
+    it "yields to the block if given" do
       uploaded_file = @uploader.upload(fakeio)
       uploaded_file.open { @called = true }
       assert @called

--- a/test/uploaded_file_test.rb
+++ b/test/uploaded_file_test.rb
@@ -238,7 +238,7 @@ describe Shrine::UploadedFile do
     it "returns the underlying IO if no block given" do
       uploaded_file = @uploader.upload(fakeio)
       assert io?(uploaded_file.open)
-      assert_equal uploaded_file.object_id, uploaded_file.object_id
+      assert_equal uploaded_file.to_io.object_id, uploaded_file.to_io.object_id
     end
 
     it "yields to the block if given" do


### PR DESCRIPTION
Please review this. I think this is what you wanted.
> It would be nice to be able to call Shrine::UploadedFile#open without a block, i.e. to make the block optional.

For the test I copied `#to_io` but I'm not sure why the object_id will be different for the same instance... could you explain what you are testing for here?
```ruby
# uploaded_file_test.rb - L241 and L377
assert_equal uploaded_file.object_id, uploaded_file.object_id
```
