### PR TITLE
Refine aws-sdk deprecation message

### DIFF
--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -7,8 +7,9 @@ begin
     raise "Shrine::Storage::S3 requires aws-sdk-s3 version 1.2.0 or above"
   end
 rescue LoadError
-  Shrine.deprecation("Using aws-sdk 2.x is deprecated and support for it will be removed in Shrine 3, use the new aws-sdk-s3 gem instead.")
-  require "aws-sdk"
+  if require "aws-sdk"
+    Shrine.deprecation("Using aws-sdk 2.x is deprecated and support for it will be removed in Shrine 3, use the new aws-sdk-s3 gem instead.")
+  end
   Aws.eager_autoload!(services: ["S3"])
 end
 require "down/chunked_io"

--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -9,6 +9,8 @@ begin
 rescue LoadError
   if require "aws-sdk"
     Shrine.deprecation("Using aws-sdk 2.x is deprecated and support for it will be removed in Shrine 3, use the new aws-sdk-s3 gem instead.")
+  else
+    raise "Shrine::Storage::S3 requires aws-sdk-s3 version 1.2.0 or above"
   end
   Aws.eager_autoload!(services: ["S3"])
 end

--- a/lib/shrine/storage/s3.rb
+++ b/lib/shrine/storage/s3.rb
@@ -2,12 +2,13 @@
 
 require "shrine"
 begin
-  require "aws-sdk-s3"
+  aws_sdk_s3_present = require "aws-sdk-s3"
+  require "aws-sdk" unless aws_sdk_s3_present
   if Gem::Version.new(Aws::S3::GEM_VERSION) < Gem::Version.new("1.2.0")
     raise "Shrine::Storage::S3 requires aws-sdk-s3 version 1.2.0 or above"
   end
 rescue LoadError
-  if require "aws-sdk"
+  if aws_sdk_s3_present
     Shrine.deprecation("Using aws-sdk 2.x is deprecated and support for it will be removed in Shrine 3, use the new aws-sdk-s3 gem instead.")
   else
     raise "Shrine::Storage::S3 requires aws-sdk-s3 version 1.2.0 or above"


### PR DESCRIPTION
When both 'aws-sdk-s3' and 'aws-sdk' are absent, this deprecation warning
```
SHRINE DEPRECATION WARNING: Using aws-sdk 2.x is deprecated and support for it will be removed in Shrine 3, use the new aws-sdk-s3 gem instead.
/Users/user/.rbenv/versions/2.4.2/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require':LoadError: cannot load such file -- aws-sdk
```
is not ideal, as it claims that one uses `aws-sdk`, when he/she does not.