### PR TITLE
Add information about json/jsonb column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Shrine.plugin :rack_file # for non-Rails apps
 ```
 
 Next decide how you will name the attachment attribute on your model, and run a
-migration that adds an `<attachment>_data` text column, which Shrine will use
+migration that adds an `<attachment>_data` `text`, `json` or `jsonb` column, which Shrine will use
 to store all information about the attachment:
 
 ```rb


### PR DESCRIPTION
It's only mentioned in the changelogs and readme, I thought it might be a good idea to promote this information a bit more.

I used monospace for `text`, `json` and `jsonb` since they declare data types, like in the [postgres docs](https://www.postgresql.org/docs/current/static/datatype-json.html).