### PR TITLE
Fixed bug in logging plugin so subclasses correctly inherits configuration

### DIFF
--- a/lib/shrine/plugins/logging.rb
+++ b/lib/shrine/plugins/logging.rb
@@ -60,7 +60,7 @@ class Shrine
         # Assigns the subclass a copy of the logger.
         def inherited(subclass)
           super
-          subclass.opts[:logging_logger] = subclass.opts[:logging_logger].dup
+          subclass.opts[:logging_logger] = subclass.opts[:logging_logger].dup if subclass.opts[:logging_logger]
         end
 
         def logger=(logger)

--- a/lib/shrine/plugins/logging.rb
+++ b/lib/shrine/plugins/logging.rb
@@ -51,32 +51,26 @@ class Shrine
       end
 
       def self.configure(uploader, opts = {})
-        uploader.opts[:logging_logger] = opts.fetch(:logger, uploader.opts[:logging_logger])
         uploader.opts[:logging_stream] = opts.fetch(:stream, uploader.opts.fetch(:logging_stream, $stdout))
+        uploader.opts[:logging_logger] = opts.fetch(:logger, uploader.opts.fetch(:logging_logger, uploader.create_logger))
         uploader.opts[:logging_format] = opts.fetch(:format, uploader.opts.fetch(:logging_format, :human))
       end
 
       module ClassMethods
-        # Assigns the subclass a copy of the logger.
-        def inherited(subclass)
-          super
-          subclass.opts[:logging_logger] = subclass.opts[:logging_logger].dup if subclass.opts[:logging_logger]
-        end
-
         def logger=(logger)
-          @logger = logger || Logger.new(nil)
+          @logger = logger
         end
 
-        # Initializes a new logger if it hasn't been initialized.
         def logger
-          @logger ||= opts[:logging_logger] || (
-            logger = Logger.new(opts[:logging_stream])
-            logger.level = Logger::INFO
-            logger.level = Logger::WARN if ENV["RACK_ENV"] == "test"
-            logger.formatter = pretty_formatter
-            opts[:logging_logger] = logger
-            logger
-          )
+          @logger ||= opts[:logging_logger]
+        end
+
+        def create_logger
+          logger = Logger.new(opts[:logging_stream])
+          logger.level = Logger::INFO
+          logger.level = Logger::WARN if ENV["RACK_ENV"] == "test"
+          logger.formatter = pretty_formatter
+          logger
         end
 
         # It makes logging preamble simpler than the default logger. Also, it

--- a/lib/shrine/plugins/logging.rb
+++ b/lib/shrine/plugins/logging.rb
@@ -57,6 +57,12 @@ class Shrine
       end
 
       module ClassMethods
+        # Assigns the subclass a copy of the logger.
+        def inherited(subclass)
+          super
+          subclass.opts[:logging_logger] = subclass.opts[:logging_logger].dup
+        end
+
         def logger=(logger)
           @logger = logger || Logger.new(nil)
         end
@@ -68,6 +74,7 @@ class Shrine
             logger.level = Logger::INFO
             logger.level = Logger::WARN if ENV["RACK_ENV"] == "test"
             logger.formatter = pretty_formatter
+            opts[:logging_logger] = logger
             logger
           )
         end

--- a/test/plugin/logging_test.rb
+++ b/test/plugin/logging_test.rb
@@ -108,4 +108,51 @@ describe Shrine::Plugins::Logging do
     assert_match "after logging",  log.lines[1]
     assert_match "STORE",          log.lines[2]
   end
+
+  it "sets default logger level set to Logger::INFO" do
+    uploader = Class.new(Shrine)
+    uploader.plugin :logging
+    assert uploader.logger.level, Logger::INFO
+  end
+
+  it "creates new Logger in subclass if logger not instantiated in Shrine" do
+    uploader = Class.new(Shrine)
+    uploader.plugin :logging
+    subclass = Class.new(uploader)
+    refute_same subclass.logger, uploader.logger
+  end
+
+  it "creates new Logger in subclass if logger is instantiated in Shrine" do
+    uploader = Class.new(Shrine)
+    uploader.plugin :logging
+    uploader.logger
+    subclass = Class.new(uploader)
+    refute_same subclass.logger, uploader.logger
+  end
+
+  it "inherits logger level for subclass from logger in Shrine" do
+    uploader = Class.new(Shrine)
+    uploader.plugin :logging
+    uploader.logger.level = Logger::WARN
+    subclass = Class.new(uploader)
+    assert_equal subclass.logger.level, uploader.logger.level
+  end
+
+  it "does not change Shrine logger level if subclass logger level is changed" do
+    uploader = Class.new(Shrine)
+    uploader.plugin :logging
+    uploader.logger.level = Logger::WARN
+    subclass = Class.new(uploader)
+    subclass.logger.level = Logger::ERROR
+    assert_equal uploader.logger.level, Logger::WARN
+  end
+
+  it "does not change subclass logger level if Shrine logger level is changed" do
+    uploader = Class.new(Shrine)
+    uploader.plugin :logging
+    uploader.logger.level = Logger::WARN
+    subclass = Class.new(uploader)
+    uploader.logger.level = Logger::ERROR
+    assert_equal subclass.logger.level, Logger::WARN
+  end
 end

--- a/test/plugin/logging_test.rb
+++ b/test/plugin/logging_test.rb
@@ -115,19 +115,19 @@ describe Shrine::Plugins::Logging do
     assert uploader.logger.level, Logger::INFO
   end
 
-  it "creates new Logger in subclass if logger not instantiated in Shrine" do
+  it "creates new Logger in Shrine if logger not instantiated in Shrine and passes it to subclass" do
     uploader = Class.new(Shrine)
     uploader.plugin :logging
     subclass = Class.new(uploader)
-    refute_same subclass.logger, uploader.logger
+    assert_same subclass.logger, uploader.logger
   end
 
-  it "creates new Logger in subclass if logger is instantiated in Shrine" do
+  it "passes logger to subclass if logger is already instantiated in Shrine" do
     uploader = Class.new(Shrine)
     uploader.plugin :logging
     uploader.logger
     subclass = Class.new(uploader)
-    refute_same subclass.logger, uploader.logger
+    assert_same subclass.logger, uploader.logger
   end
 
   it "inherits logger level for subclass from logger in Shrine" do
@@ -138,21 +138,21 @@ describe Shrine::Plugins::Logging do
     assert_equal subclass.logger.level, uploader.logger.level
   end
 
-  it "does not change Shrine logger level if subclass logger level is changed" do
+  it "does change Shrine logger level if subclass logger level is changed" do
     uploader = Class.new(Shrine)
     uploader.plugin :logging
     uploader.logger.level = Logger::WARN
     subclass = Class.new(uploader)
     subclass.logger.level = Logger::ERROR
-    assert_equal uploader.logger.level, Logger::WARN
+    assert_equal uploader.logger.level, Logger::ERROR
   end
 
-  it "does not change subclass logger level if Shrine logger level is changed" do
+  it "does change subclass logger level if Shrine logger level is changed" do
     uploader = Class.new(Shrine)
     uploader.plugin :logging
     uploader.logger.level = Logger::WARN
     subclass = Class.new(uploader)
     uploader.logger.level = Logger::ERROR
-    assert_equal subclass.logger.level, Logger::WARN
+    assert_equal subclass.logger.level, Logger::ERROR
   end
 end


### PR DESCRIPTION
Fixed a bug in the logging plugin where the logger of Shrine's subclass does not inherit the logging level from Shrine. With this fix, the subclass now correctly inherits the logging level from Shrine and is a copy of the logger so it can be independently configured if needed without affecting the base Shrine logger or other subclass's logger configuration.

I left the default logging level to Logger::INFO which is the current default previously set in the code. This is different from what's stated in issue #246.

Tests added to ensure the behavior reflects the correct inheritance model as described in the issue.

Fixes #246.