### PR TITLE
Prefer registered MIME types with the mime-types analyzer

### DIFF
--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -201,7 +201,7 @@ class Shrine
           require "mime/types"
 
           if filename = extract_filename(io)
-            mime_type = MIME::Types.of(filename).first
+            mime_type = MIME::Types.of(filename).partition(&:registered?).flatten.first
             mime_type.content_type if mime_type
           end
         end

--- a/test/plugin/determine_mime_type_test.rb
+++ b/test/plugin/determine_mime_type_test.rb
@@ -121,6 +121,10 @@ describe Shrine::Plugins::DetermineMimeType do
     it "returns nil for empty IOs" do
       assert_nil @shrine.determine_mime_type(fakeio(""))
     end
+
+    it "prioritizes text/csv as registered, over text/comma-separated-values" do
+      assert_equal "text/csv", @shrine.determine_mime_type(fakeio(filename: "report.csv"))
+    end
   end
 
   describe ":mini_mime analyzer" do


### PR DESCRIPTION
(This is potentially a breaking change, depending on how strict downstream applications are about media type return values.)

This was specifically written to make CSV file extensions map to text/csv instead of text/comma-separated-values when using the mime-types gem, but will more generally prefer registered types over un-registered types.

The IANA Media Types registry (referencing RFC 4180 and RFC 7111) say that the media type for CSV is text/csv. Because of the way the mime-types gem implements MIME::Types.of(filename), you get text/comma-separated-values as listed first for a CSV:

```ruby
MIME::Types.of("csv")
# => [#<MIME::Type: text/comma-separated-values>, #<MIME::Type: text/csv>]
```

Since `MIME::Type#registered?` indicates that `text/csv` is a registered type, this change makes that the preferred media type for CSV files.

See mime-types/ruby-mime-types#92 for a related issue about fixing this in the mime-types gem.